### PR TITLE
google-sync refactoring and deleting projects

### DIFF
--- a/backend/calendar.js
+++ b/backend/calendar.js
@@ -255,7 +255,8 @@ const getGoogleEvents = async (req, res) => {
 
     res.status(StatusCodes.OK).send(allEvents);
 
-    // /*
+
+    /* 
     GoogleEventModel.updateMany(
         { email: email },
         {
@@ -274,13 +275,24 @@ const getUnsyncedGoogleEvents = async (req, res) => {
     const email = await utils.getEmailFromReq(req);
     const accessToken = await utils.getAccessTokenFromRequest(req);
     let unsyncedEvents = [];
+    let deletedCalendarEvents = [];
     let error = null;
 
     // TODO: use two promises above and then promise all once emal and access token are retrieved
     try {
         // / Method 1: receive unsynced events from Google directly and isert them into DB
+        // // [unsyncedEvents, deletedCalendarEvents] = await googleSync.syncGoogleData(accessToken, email);
         unsyncedEvents = await googleSync.syncGoogleData(accessToken, email);
-        console.log(`[getUnsyncedGoogleEvents] Fetching for ${email}. Unsynced events: ${unsyncedEvents.length}`);
+
+        console.log(`[getUnsyncedGoogleEvents] Fetching for ${email}.`);
+        if (unsyncedEvents.length > 0) {
+            console.log(`Unsynced events: ${unsyncedEvents.length}.`);
+        }
+
+        // // if (deletedCalendarEvents.length > 0) {
+        // //     console.log(`Deleted calendars events: ${deletedCalendarEvents.length}.`);
+        // // }
+
 
         // / Method 2: receive from DB. Good if we use intervals server-side to update.
         /*

--- a/backend/dal/dbUsers.js
+++ b/backend/dal/dbUsers.js
@@ -1,0 +1,10 @@
+
+const UserModel = require('./models/user');
+
+async function updateOne(filter, update, options) {
+    return UserModel.updateOne(filter, update, options);
+}
+
+module.exports = {
+    // updateOne: updateOne,
+}

--- a/backend/models/googleevent.js
+++ b/backend/models/googleevent.js
@@ -23,6 +23,7 @@ const googleEventSchema = new Schema({
     email: String,
     fetchedByUser: Boolean,
     isGoogleEvent: Boolean,
+    status: String,
     extendedProperties: {
         private: {
             fullCalendarEventId: String,

--- a/backend/projects.js
+++ b/backend/projects.js
@@ -414,10 +414,10 @@ const deleteProject = async (req, res) => {
                                 calendarId: googleCalendarId,
                         })
                 } else {
-                        let deleteLocalDocs = EventModel.deleteMany({ 'projectId': projectId });
+                        let deleteLocalDocs = await EventModel.deleteMany({ 'projectId': projectId }); // Didn't work without await for some reason
                 }
 
-                let deleteProjectDocs = ProjectModel.deleteOne({ 'id': projectId });
+                let deleteProjectDocs = await ProjectModel.deleteOne({ 'id': projectId });
         } catch (err) {
                 errorMsg = err;
                 console.error(err);

--- a/backend/users.js
+++ b/backend/users.js
@@ -16,7 +16,7 @@ const createUserDataFromCode = async (req, res) => {
     const update = { $set: { email: email } };
     const options = { upsert: true };
     await UserModel.updateOne(query, update, options);
-    await googleSync.resetEventsFetchStatus(email);
+    // await googleSync.resetEventsFetchStatus(email);
     await googleSync.syncGoogleData(accessToken, email);
     // let syncInterval = setInterval(syncGoogleEvents, 8000, accessToken, email);
     // TODO: save sync interval ID so we can later stop it when user logs out?

--- a/frontend/src/components/Project.js
+++ b/frontend/src/components/Project.js
@@ -10,7 +10,10 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 import Tooltip from "@material-ui/core/Tooltip";
-const EventsAPI = require('../apis/EventsAPI.js')
+import { ButtonGroup } from '@mui/material';
+import { ThreeDots } from 'react-loader-spinner';
+const EventsAPI = require('../apis/EventsAPI.js');
+
 
 export const Project = (props) => {
     const [projectTitle, setProjectName] = useState(props.project.title);
@@ -24,6 +27,7 @@ export const Project = (props) => {
     const [totalHoursPast, setTotalHoursPast] = useState();
     const [totalHoursFuture, setTotalHoursFuture] = useState();
     const [totalHoursExpected, setTotalHoursExpected] = useState();
+    const [isProcessing, setIsProcessing] = useState(false);
     const componentMounted = useRef(true);
 
     useEffect(() => {
@@ -41,7 +45,7 @@ export const Project = (props) => {
     // TODO: add abort controller!
 
 
-    
+
     // Old events
     useEffect(() => {
         const oldEvents = projectEvents.filter(event => {
@@ -200,11 +204,15 @@ export const Project = (props) => {
 
     const handleConfirmDelete = () => {
         setOpenDeleteDialog(false);
+        setIsProcessing(true);
         props.deleteProject(props.project);
+        setIsProcessing(false);
     }
 
     const handleOnExportClick = () => {
+        setIsProcessing(true);
         props.exportProject(props.project);
+        setIsProcessing(false);
     }
 
     return (
@@ -277,17 +285,26 @@ export const Project = (props) => {
                     </tr>
                 </tbody>
             </table>
-            <Button variant='contained' onClick={handleOnEditClick} disabled={isBeingEdited}>Edit</Button>
-            <Button variant='contained' onClick={handleOnCancel} disabled={!isBeingEdited}>Cancel</Button>
-            <Button variant='contained' onClick={handleOnSave} disabled={!isBeingEdited}>Save</Button>
-            <Tooltip title="Deletes the project and all its events. If the project is already exported, it deletes the calendar from Google Calendar.">
-                <Button variant='contained' onClick={handleOnDeleteClick}>Delete</Button>
-            </Tooltip>
-            {!props.project.exportedToGoogle &&
-                <Tooltip title="Export all the project's events to your Google calendar. This creates a new Calendar for the events.">
-                    <Button variant='contained' onClick={handleOnExportClick}>Export</Button>
+            <ButtonGroup
+                variant='contained'
+            >
+                <Button variant='contained' onClick={handleOnEditClick} disabled={isBeingEdited || isProcessing}>Edit</Button>
+                <Button variant='contained' onClick={handleOnCancel} disabled={!isBeingEdited || isProcessing}>Cancel</Button>
+                <Button variant='contained' onClick={handleOnSave} disabled={!isBeingEdited || isProcessing}>Save</Button>
+                <Tooltip title="Deletes the project and all its events. If the project is already exported, it deletes the calendar from Google Calendar.">
+                    <Button variant='contained' onClick={handleOnDeleteClick} disabled={isProcessing}>Delete</Button>
                 </Tooltip>
-            }
+                {!props.project.exportedToGoogle &&
+                    <Tooltip title="Export all the project's events to your Google calendar. This creates a new Calendar for the events.">
+                        <Button variant='contained' onClick={handleOnExportClick} disabled={isProcessing}>Export</Button>
+                    </Tooltip>
+                }
+            </ButtonGroup>
+            <div hidden={!isProcessing} className="center_text">
+                <h5>Working on it</h5>
+                <ThreeDots color="#00BFFF" height={80} width={80} />
+            </div>
+
             <Dialog
                 open={openDeleteDialog}
                 onClose={handleCancelDelete}

--- a/frontend/src/components/ProjectsAccordion.js
+++ b/frontend/src/components/ProjectsAccordion.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { styled } from '@mui/material/styles';
+import { ThreeDots } from 'react-loader-spinner'
 import ArrowForwardIosSharpIcon from '@mui/icons-material/ArrowForwardIosSharp';
 import MuiAccordion from '@mui/material/Accordion';
 import MuiAccordionSummary from '@mui/material/AccordionSummary';

--- a/frontend/src/pages/Schedules.js
+++ b/frontend/src/pages/Schedules.js
@@ -255,6 +255,10 @@ export class Schedules extends React.Component {
         if (!googleEvent.extendedProperties.private) {
             return id;
         }
+        
+        if (!googleEvent.extendedProperties.private.fullCalendarEventID) {
+            return id;
+        }
 
         return googleEvent.extendedProperties.private.fullCalendarEventID;
     }


### PR DESCRIPTION
	-	Major refactoring of the google-sync functions. Many functions performed multiple things. I broke them down into several different functions, created more functions where ones were too big. Separated many responsibilities. I've tried to minimize functions performing actions that aren't clear from their name. For example, some functions both fetched and updated the DB. I separated such code, so fetch only fetches, without updating anything (the sync tokens in paricular).
	-	The above change meant that I made much more use of "await" than was in the previous version, that was much more asynchronous.
		I can perhaps optimize it later with less "awaits", but I wanted it simple to just get it working with the refactoring.
	-	Deleting a Google calendar that was an exported project of ours now also deletes the events in real time on the website. The server also checks if the deleted calendar was associated with a project, and if so it deletes the relevant project object as well.