### PR TITLE
access roles

### DIFF
--- a/backend/calendar.js
+++ b/backend/calendar.js
@@ -208,65 +208,22 @@ const deleteGoogleEvent = async (req) => {
 
 const getGoogleEvents = async (req, res) => {
     const email = utils.getEmailFromReq(req);
-
-    // const allEvents = await dbGoogleEvents.find({ email: email, fetchedByUser: false });
     const allEvents = await dbGoogleEvents.find({ email: email });
-
     res.status(StatusCodes.OK).send(allEvents);
-
-    /* 
-    GoogleEventModel.updateMany(
-        { email: email },
-        {
-            $set:
-            {
-                fetchedByUser: true,
-            }
-        })
-        .then(res => {
-            console.log(`Finished updating user ${email} Google events to fetched.`);
-        })
-    // */
 }
 
 const getUnsyncedGoogleEvents = async (req, res) => {
     const email = utils.getEmailFromReq(req);
     const accessToken = await utils.getAccessTokenFromRequest(req);
     let unsyncedEvents = [];
-    let deletedCalendarEvents = [];
     let error = null;
 
-    // TODO: use two promises above and then promise all once emal and access token are retrieved
     try {
-        // / Method 1: receive unsynced events from Google directly and isert them into DB
-        // // [unsyncedEvents, deletedCalendarEvents] = await googleSync.syncGoogleData(accessToken, email);
         unsyncedEvents = await googleSync.syncGoogleData(accessToken, email);
-
         console.log(`[getUnsyncedGoogleEvents] Fetching for ${email}.`);
         if (unsyncedEvents.length > 0) {
             console.log(`Unsynced events: ${unsyncedEvents.length}.`);
         }
-
-        // // if (deletedCalendarEvents.length > 0) {
-        // //     console.log(`Deleted calendars events: ${deletedCalendarEvents.length}.`);
-        // // }
-
-
-        // / Method 2: receive from DB. Good if we use intervals server-side to update.
-        /*
-        {    
-            unsyncedEvents = await GoogleEventModel.find({ email: email, fetchedByUser: false });
-            GoogleEventModel.updateMany( // Avoid await?
-            { email: email },
-            {
-                $set:
-                {
-                    fetchedByUser: true,
-                }
-            }
-            )
-        }
-        // */
     } catch (err) {
         console.log(`[getUnsyncedGoogleEvents] Error:\n${err}`)
         error = err;

--- a/backend/dal/dbUsers.js
+++ b/backend/dal/dbUsers.js
@@ -20,7 +20,7 @@ async function removeDeletedCalendars(email, deletedCalendarsId) {
     let promise = null;
     if (deletedCalendarsId.length > 0) {
         // Remove deleted calendars from the user's sync token array.
-        await Model.updateOne(
+        promise = await Model.updateOne(
             { email: email },
             {
                 $pull: {

--- a/backend/models/google-event.js
+++ b/backend/models/google-event.js
@@ -24,6 +24,7 @@ const googleEventSchema = new Schema({
     fetchedByUser: Boolean,
     isGoogleEvent: Boolean,
     status: String,
+    accessRole: String,
     extendedProperties: {
         private: {
             fullCalendarEventId: String,

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -8,6 +8,15 @@ const EventModel = require('./models/unexported-event')
 const GoogleEventModel = require('./models/google-event')
 const consts = require('./consts');
 
+const websiteMainColor = '#282c34';
+
+const googleAccessRole = {
+    none: 'none',
+    freeBusyReader: 'freeBusyReader',
+    reader: 'reader',
+    writer: 'writer',
+    owner: 'owner',
+}
 
 const transporter = nodemailer.createTransport({
     service: 'gmail',
@@ -203,6 +212,8 @@ function isValidDate(date) {
 
 module.exports = {
     oauth2Client: oauth2Client,
+    websiteMainColor: websiteMainColor,
+    googleAccessRole: googleAccessRole,
     generateId: generateId,
     getAccessTokenFromRequest: getAccessTokenFromRequest,
     getEmailFromReq: getEmailFromReq,

--- a/frontend/src/components/MainPagesContainer.js
+++ b/frontend/src/components/MainPagesContainer.js
@@ -19,7 +19,7 @@ export const MainPagesContainer = (props) => {
     const pages = [{
       name: "Schedules",
       relativePath: "/schedules",
-      element: <Schedules setEvents={setEvents} setMsg={props.setMsg} />
+      element: <Schedules setEvents={setEvents} setNotificationMsg={props.setMsg} />
     },{
       name: "Projects",
       relativePath: "/projects",

--- a/frontend/src/event-utils.js
+++ b/frontend/src/event-utils.js
@@ -1,0 +1,47 @@
+const googleAccessRole = {
+    none: 'none',
+    freeBusyReader: 'freeBusyReader',
+    reader: 'reader',
+    writer: 'writer',
+    owner: 'owner',
+}
+
+const noPermissionMsg = "No permission to modify this event.";
+
+function accessRoleAllowsWritingFCEvent(fcEvent) {
+    if (!fcEvent) {
+        return false;
+    }
+
+    if (!fcEvent.extendedProps) {
+        return false;
+    }
+
+    let accessRole = fcEvent.extendedProps.accessRole;
+
+    if (!accessRole) {
+        return false;
+    }
+
+    return accessRole === googleAccessRole.writer || accessRole === googleAccessRole.owner;
+}
+
+function accessRoleAllowsWritingGEvent(gEvent) {
+    if (!gEvent) {
+        return false;
+    }
+
+    let accessRole = gEvent.accessRole;
+
+    if (!accessRole) {
+        return false;
+    }
+
+    return accessRole === googleAccessRole.writer || accessRole === googleAccessRole.owner;
+}
+
+module.exports = {
+    noPermissionMsg: noPermissionMsg,
+    accessRoleAllowsWritingFCEvent: accessRoleAllowsWritingFCEvent,
+    accessRoleAllowsWritingGEvent: accessRoleAllowsWritingGEvent,
+}

--- a/frontend/src/styles/style.css
+++ b/frontend/src/styles/style.css
@@ -1,99 +1,123 @@
-#editEventTable .MuiFormControl-root{
+:root {
+  --main-bg-color: #282c34;
+}
+
+#editEventTable .MuiFormControl-root {
   margin: 5px !important;
 }
 
-#schedule-container{
+#schedule-container {
   margin: 1.5%;
 }
 
 /** MUI **/
-.MuiOutlinedInput-root:hover fieldset, .Mui-focused fieldset, .MuiOutlinedInput-root fieldset{
-  border-color: white!important;
+.MuiOutlinedInput-root:hover fieldset,
+.Mui-focused fieldset,
+.MuiOutlinedInput-root fieldset {
+  border-color: white !important;
 }
-.whiteTimeFont .MuiOutlinedInput-input, .MuiOutlinedInput-root, .MuiChip-root, .MuiAccordion-root{ 
-  color: white!important;
+
+.whiteTimeFont .MuiOutlinedInput-input,
+.MuiOutlinedInput-root,
+.MuiChip-root,
+.MuiAccordion-root {
+  color: white !important;
 }
-.MuiOutlinedInput-root fieldset{
+
+.MuiOutlinedInput-root fieldset {
   color: black;
 }
-.MuiAccordion-root{
-  background-color: transparent!important;
+
+.MuiAccordion-root {
+  background-color: transparent !important;
 }
-.MuiChip-root{
-  background-color: rgb(75, 75, 75)!important;
+
+.MuiChip-root {
+  background-color: rgb(75, 75, 75) !important;
 }
-.MuiMenuItem-root{
-  display: flex!important;
+
+.MuiMenuItem-root {
+  display: flex !important;
 }
-.MuiPaper-root{
-  min-width: 0px!important;
+
+.MuiPaper-root {
+  min-width: 0px !important;
 }
-.accordion > div{
+
+.accordion>div {
   width: 50%;
   margin: auto;
 }
 
 /** coloring the calendar's day headers (they were white so text was invisible) in Scheduels page **/
-.fc-col-header{
-  background-color:#282c34;
+.fc-col-header {
+  background-color: var(--main-bg-color)
 }
 
 /** center the loader animation **/
-div svg{
+div svg {
   margin: auto;
 }
+
 /**/
 
-.border{
+.border {
   border: 1px solid white;
   padding: 10px;
 }
 
-.horizontalAlign{
+.horizontalAlign {
   float: left;
   clear: none;
 }
 
 /** NavBar **/
-.nav-bar{
-  background-color: rgb(21, 21, 21)!important;
+.nav-bar {
+  background-color: rgb(21, 21, 21) !important;
 }
-.nav-bar ul{
+
+.nav-bar ul {
   padding: 0px;
   margin-left: 25%;
   margin-right: 25%;
-} 
-.nav-bar li{
+}
+
+.nav-bar li {
   padding: 8px;
   display: inline;
 }
-.nav-bar li a:hover{
+
+.nav-bar li a:hover {
   background-color: #0b0b0b;
 }
-.nav-bar .active{
+
+.nav-bar .active {
   border-bottom: white 2px solid;
 }
-.nav-bar li a{
-  color:white;
+
+.nav-bar li a {
+  color: white;
   text-decoration: none;
 }
+
 /**/
 
 /** General page layout **/
 .app-header {
-  background-color: #282c34;
+  background-color: var(--main-bg-color);
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
   font-size: calc(10px + 2vmin);
-  color: white!important;
+  color: white !important;
 }
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-  'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-  sans-serif;
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -102,17 +126,21 @@ body {
   border-width: 7px;
 }
 
-.center_elem{
+.center_elem {
   margin: auto;
 }
-.center_text{
+
+.center_text {
   text-align: center;
 }
-.full_width{
-  width:100%;
+
+.full_width {
+  width: 100%;
 }
-.full_width td{
+
+.full_width td {
   vertical-align: top;
   width: 50%;
 }
+
 /**/


### PR DESCRIPTION
Google Calendars have different permissions. Previously our app allowed modifying any event on your calendar, even if it's an event you're just invited to, or one that is shared but you have no permission to edit.
Now we've changed it to make use of Google's access roles.

Back:
	-	When retrieveing Google events we check on a per-event basis what is its access role, based on the calendar and the event itself.
	-	Events which are invitations appear on your primary calendar, which has an 'owner' access role. The events themselves, however, cannot be modified.
		For such events we check if the user is an attendee, and if guests can modify (all fields of the Google event resource).

Front:
	-	When adding Google events at the front we check the access role and it determines if the event is editable.

Bugs:
	-	Fixed a bug where calendars sync token was not updated (forgot to send the argument to the function!)