### PR TITLE
Syncing unexported events

### DIFF
--- a/backend/business-logic/projects/projects.js
+++ b/backend/business-logic/projects/projects.js
@@ -475,6 +475,7 @@ const insertEventsToGoogleCalendar = async (req, unexportedEvents, project, cale
                                 }
                         }
 
+                        // Google does not accept null values in the fields of extended properties, so we first check
                         if (event.sharedId) resource.extendedProperties.private.fullCalendarEventSharedId = event.sharedId;
 
                         const response = await gapi.events.insert({

--- a/backend/dal/dbUnexportedEvents.js
+++ b/backend/dal/dbUnexportedEvents.js
@@ -73,6 +73,24 @@ async function findByProject(email, projectId) {
 }
 
 /**
+ * Returns all the user's unexported events whose timestamp is greater than the one given.
+ * @param {*} email 
+ * @param {*} timeStamp A timestamp by which to filter - only events with a timestamp greater than this one will be returned.
+ */
+async function findByTimestamp(email, timeStamp) {
+    let promise = await Model.find(
+        {
+            email: email,
+            updatedAt: {
+                $gt: new Date(timeStamp),
+            }
+        }
+    )
+
+    return promise;
+}
+
+/**
  * When patching a project, certain fields also "trickle down" to the events.
  * This updates all events related to the updated project, with the new fields.
  * @param {*} projectId The ID of the project that was patched.
@@ -170,6 +188,7 @@ module.exports = {
 
     // Custom Functions
     findByProject: findByProject,
+    findByTimestamp: findByTimestamp,
     patchEventsFromProjectPatch: patchEventsFromProjectPatch,
     deleteTags: deleteTags,
 }

--- a/backend/models/unexported-event.js
+++ b/backend/models/unexported-event.js
@@ -1,27 +1,31 @@
-const mongoose  = require("mongoose");
+const mongoose = require("mongoose");
 const Schema = mongoose.Schema;
 
-const unexportedEventSchema = new Schema({
-    title: String,
-    id: String,
-    sharedId: String,
-    projectTitle: String,
-    projectId: String,
-    projectSharedId: String,
-    gEventId: String, // The ID of the Google event this local event is tied to
-    calendarId: String, // The ID of the Google calendar this event is attached to, in case of partially exported projects
-    start: Date,
-    end: Date,
-    backgroundColor: String,
-    unexportedEvent: Boolean,
-    email: String,
-
-    tags: {
-        independentTagIds: [String],
-        projectTagIds: [String],
-        ignoredProjectTagIds: [String],
+const unexportedEventSchema = new Schema(
+    {
+        title: String,
+        id: String,
+        sharedId: String,
+        projectTitle: String,
+        projectId: String,
+        projectSharedId: String,
+        gEventId: String, // The ID of the Google event this local event is tied to
+        calendarId: String, // The ID of the Google calendar this event is attached to, in case of partially exported projects
+        start: Date,
+        end: Date,
+        backgroundColor: String,
+        unexportedEvent: Boolean,
+        email: String,
+        tags: {
+            independentTagIds: [String],
+            projectTagIds: [String],
+            ignoredProjectTagIds: [String],
+        },
     },
-})
+    {
+        timestamps: true,
+    },
+)
 
 const UnexportedEvent = mongoose.model('UnexportedEvent', unexportedEventSchema);
 module.exports = UnexportedEvent;

--- a/frontend/src/apis/EventsAPI.js
+++ b/frontend/src/apis/EventsAPI.js
@@ -5,6 +5,7 @@ const APIUtils = require('./APIUtils.js');
 const basicValidStatus = [200];
 const validStatusArr_fetchGoogleEvents = basicValidStatus;
 const validStatusArr_fetchUnsyncedGoogleEvents = basicValidStatus;
+const validStatusArr_fetchUnsyncedUnexportedEvents = basicValidStatus;
 const validStatusArr_fetchAllProjectEvents = basicValidStatus;
 const validStatusArr_fetchProjectEvents = basicValidStatus;
 const validStatusArr_fetchAllEvents = basicValidStatus;
@@ -47,6 +48,32 @@ async function fetchUnsyncedGoogleEventsData() {
 
 async function fetchUnsyncedGoogleEventsRes() {
     const responsePromise = fetch(`${consts.fullRouteEvents}/google/unsynced`, {
+        headers: consts.standardHeaders,
+        method: 'GET',
+    });
+
+    return responsePromise;
+}
+
+async function fetchUnsyncedUnexportedEventsData(timeStamp) {
+    if (!timeStamp) return null;
+
+    let dataPromise = fetchUnsyncedUnexportedEventsRes(timeStamp)
+        .then(response => {
+            if (APIUtils.isValidStatus(response, validStatusArr_fetchUnsyncedUnexportedEvents)) {
+                return apiUtils.getResData(response);
+            } else {
+                return null;
+            }
+        })
+
+    return dataPromise;
+}
+
+async function fetchUnsyncedUnexportedEventsRes(timeStamp) {
+    if (!timeStamp) return null;
+
+    const responsePromise = fetch(`${consts.fullRouteEvents}/unexported/unsynced/${new Date(timeStamp).toISOString()}`, {
         headers: consts.standardHeaders,
         method: 'GET',
     });
@@ -133,6 +160,7 @@ module.exports = {
     fetchGoogleEventsData: fetchGoogleEventsData,
     fetchAllProjectEventsData: fetchAllUnexportedEventsData,
     fetchUnsyncedGoogleEventsData: fetchUnsyncedGoogleEventsData,
+    fetchUnsyncedUnexportedEventsData: fetchUnsyncedUnexportedEventsData,
     fetchProjectEventsData: fetchProjectEventsData,
     updateEvent: updateEvent,
     deleteEvent: deleteEvent,

--- a/frontend/src/utils/event-utils.js
+++ b/frontend/src/utils/event-utils.js
@@ -98,6 +98,23 @@ function fc_GetIgnoredProjectTagIds(fcEvent) {
 }
 
 /**
+ * @returns [independentTagsIds, projectTagIds, ignoredProjectTagIds], null if they don't exist.
+ */
+ function unex_GetAllTagIds(unexEvent) {
+    let independentTagsIds = unex_GetTagsByField(unexEvent, 'independentTagIds');
+    let projectTagIds = unex_GetTagsByField(unexEvent, 'projectTagIds');
+    let ignoredProjectTagIds = unex_GetTagsByField(unexEvent, 'ignoredProjectTagIds');
+
+    return [independentTagsIds, projectTagIds, ignoredProjectTagIds];
+}
+
+function unex_GetTagsByField(unexEvent, fieldName) {
+    if (!unexEvent) return null;
+    if (!unexEvent.tags) return null;
+    return unexEvent.tags[fieldName];
+}
+
+/**
  * @returns [independentTagIds, projectTagIds, ignoredProjectTagIds], null if they don't exist.
  */
 function g_GetAllTagsIds(gEvent) {
@@ -110,9 +127,14 @@ function g_GetAllTagsIds(gEvent) {
 
 function g_GetTagIdsByField(gEvent, fieldName) {
     if (!gEvent) return null;
-    if (!gEvent.extendedProperties) return null;
-    if (!gEvent.extendedProperties.private) return null;
-    return gEvent.extendedProperties.private[fieldName];
+    if (!gEvent.tags) return null;
+    return gEvent.tags[fieldName];
+    
+    // ! DELETE if all works well Old version, where tags were saved in extended properties
+    // // if (!gEvent) return null;
+    // // if (!gEvent.extendedProperties) return null;
+    // // if (!gEvent.extendedProperties.private) return null;
+    // // return gEvent.extendedProperties.private[fieldName];
 
 
     // ! DELETE if all works - old code from when we saved google events in our DB wtih String in extended properties, not arrayss (to match Google resource which accepts only strings)
@@ -256,6 +278,7 @@ module.exports = {
 
     fc_isProjectEvent: fc_isProjectEvent,
 
+    unex_GetAllTagIds: unex_GetAllTagIds,
     g_GetAllTagsIds: g_GetAllTagsIds,
     fc_GetAllTagIds: fc_GetAllTagIds,
     fc_GetProjectTagIds: fc_GetProjectTagIds,


### PR DESCRIPTION
	-	Added timestamps to unexported events model. An option offered by mongoose which adds a createdAt and updatedAt fields:
		https://mongoosejs.com/docs/timestamps.html

	-	Front: When fetching all unexported events, the latest timestamp of the array is checked and saved.
	-	Front: the periodic sync for Google events has been expanded to also sync unexported events, by sending the latest timestamp.